### PR TITLE
Chore/fix logger

### DIFF
--- a/bin/mdi-logger
+++ b/bin/mdi-logger
@@ -3,34 +3,45 @@
 
 require "bunny"
 
-if ARGV.empty?
-  abort "Usage: #{$0} [binding key]"
-end
+# if ARGV.empty?
+#   abort "Usage: #{$0} [binding key]"
+# end
 
 host = ENV['MB_REMOTE_HOST'] || 'localhost'
 
 conn = Bunny.new(host: host)
 conn.start
 
-ch  = conn.create_channel
-x   = ch.topic("results")
-q   = ch.queue("", :exclusive => true)
+ch = conn.create_channel
+q  = ch.queue("results")
 
-ARGV.each do |severity|
-  q.bind(x, :routing_key => severity)
-  puts "     binding q to x with key: #{severity}"
+puts " [*] Waiting for messages in #{q.name}. To exit press CTRL+C"
+q.subscribe(:ack => true, :block => true) do |delivery_info, properties, body|
+  puts " [x] Received '#{body}'"
+  print "     "
+  ch.ack(delivery_info.delivery_tag)
 end
 
-puts " [*] Waiting for logs. To exit press CTRL+C"
 
-msgs_handled = 0
-begin
-  q.subscribe(:block => true) do |delivery_info, properties, body|
-    puts " [x] #{delivery_info.routing_key}:#{body}"
-    msgs_handled += 1
-  end
-rescue Interrupt => _
-  $stderr.puts("========> Handled #{msgs_handled} messages <========")
-  ch.close
-  conn.close
-end
+# ch  = conn.create_channel
+# x   = ch.topic("results")
+# q   = ch.queue("", :exclusive => true)
+
+# ARGV.each do |severity|
+#   q.bind(x, :routing_key => severity)
+#   puts "     binding q to x with key: #{severity}"
+# end
+
+# puts " [*] Waiting for logs. To exit press CTRL+C"
+
+# msgs_handled = 0
+# begin
+#   q.subscribe(:block => true) do |delivery_info, properties, body|
+#     puts " [x] #{delivery_info.routing_key}:#{body}"
+#     msgs_handled += 1
+#   end
+# rescue Interrupt => _
+#   $stderr.puts("========> Handled #{msgs_handled} messages <========")
+#   ch.close
+#   conn.close
+# end

--- a/bin/mdi-logger
+++ b/bin/mdi-logger
@@ -13,35 +13,22 @@ conn = Bunny.new(host: host)
 conn.start
 
 ch = conn.create_channel
+x  = ch.direct("dummy", durable: true)
 q  = ch.queue("results")
 
+q.bind(x, :routing_key => 'results')
+
 puts " [*] Waiting for messages in #{q.name}. To exit press CTRL+C"
-q.subscribe(:ack => true, :block => true) do |delivery_info, properties, body|
-  puts " [x] Received '#{body}'"
-  print "     "
-  ch.ack(delivery_info.delivery_tag)
+
+
+msgs_handled = 0
+begin
+  q.subscribe(:block => true) do |delivery_info, properties, body|
+    puts " [x] #{delivery_info.routing_key}:#{body}"
+    msgs_handled += 1
+  end
+rescue Interrupt => _
+  $stderr.puts("========> Handled #{msgs_handled} messages <========")
+  ch.close
+  conn.close
 end
-
-
-# ch  = conn.create_channel
-# x   = ch.topic("results")
-# q   = ch.queue("", :exclusive => true)
-
-# ARGV.each do |severity|
-#   q.bind(x, :routing_key => severity)
-#   puts "     binding q to x with key: #{severity}"
-# end
-
-# puts " [*] Waiting for logs. To exit press CTRL+C"
-
-# msgs_handled = 0
-# begin
-#   q.subscribe(:block => true) do |delivery_info, properties, body|
-#     puts " [x] #{delivery_info.routing_key}:#{body}"
-#     msgs_handled += 1
-#   end
-# rescue Interrupt => _
-#   $stderr.puts("========> Handled #{msgs_handled} messages <========")
-#   ch.close
-#   conn.close
-# end

--- a/lib/mdi/bag_validator/base.rb
+++ b/lib/mdi/bag_validator/base.rb
@@ -32,6 +32,8 @@ module Mdi
         puts "STATUS:"
         puts "#{s}"
         puts "============================================================="
+        p = Sneakers::Publisher.new
+        p.publish('test message', to_queue: 'results')
         ack!
       end
     end

--- a/lib/mdi/bag_validator/base.rb
+++ b/lib/mdi/bag_validator/base.rb
@@ -32,8 +32,8 @@ module Mdi
         puts "STATUS:"
         puts "#{s}"
         puts "============================================================="
-        p = Sneakers::Publisher.new
-        p.publish('test message', to_queue: 'results')
+        result_msg = "bag_validation of :#{msg}: " + (s == 0 ? 'passed' : 'FAILED')
+        publish(result_msg, to_queue: 'results', routing_key: 'results')
         ack!
       end
     end


### PR DESCRIPTION
Tweak configuration and publisher settings so that the worker and logger
  communicate correctly, specifically:

  a.) the worker thread invokes the 'publish' method with the correct
      queue and routing key

  b.) the logger subscribes to the correct exchange and queue
